### PR TITLE
Rendering refactoring

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,10 @@
 2.1.0 (unreleased)
 ------------------
 
+- The attributes renderer knows about the element indentation
+  and for indents the attributes consequently [ale-rt]
+- The ZCML element has now its custom tag templates, this simplifies the code [ale-rt]
+- Attributes content spanning multiple lines is not indented anymore (Refs. #17) [ale-rt]
 - Improved sorting for zcml attributes (Refs. #11) [ale-rt]
 - Code is compliant with black 20.8b1 [ale-rt]
 - Switch to pytest for running tests [ale-rt]

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ with-coverage=1
 cover-erase=1
 
 [flake8]
-ignore = W504
+ignore = E203, W503, W504
 max-line-length = 88
 
 [aliases]

--- a/zpretty/elements.py
+++ b/zpretty/elements.py
@@ -64,13 +64,16 @@ class PrettyElement(object):
     first_attribute_on_new_line = False
     before_closing_multiline = ""
 
-    self_closing_singleline_template = "{prefix}<{tag}{attributes}/>"
+    self_closing_singleline_attributeless_template = "{prefix}<{tag} />"
+    self_closing_singleline_attributefull_template = "{prefix}<{tag} {attributes} />"
     self_closing_multiline_template = "\n".join(
-        (u"{prefix}<{tag}{attributes}", "{prefix}{before_closing_multiline}/>")
+        ("{prefix}<{tag} {attributes}", "{prefix}{before_closing_multiline}/>")
     )
-    start_tag_singleline_template = "{prefix}<{tag}{attributes}>"
+
+    start_tag_singleline_attributeless_template = "{prefix}<{tag}>"
+    start_tag_singleline_attributefull_template = "{prefix}<{tag} {attributes}>"
     start_tag_multiline_template = "\n".join(
-        (u"{prefix}<{tag}{attributes}", "{prefix}{before_closing_multiline}>")
+        ("{prefix}<{tag} {attributes}", "{prefix}{before_closing_multiline}>")
     )
     escaper = EntitySubstitution()
 
@@ -153,6 +156,9 @@ class PrettyElement(object):
         """Check if this element is a processing instruction like <?xml...>"""
         return isinstance(self.context, ProcessingInstruction)
 
+    def has_many_attributes(self):
+        return len(self.attributes) > 1
+
     @memo
     def getparent(self):
         """Return the element parent as an instance of this class"""
@@ -224,20 +230,21 @@ class PrettyElement(object):
             content = rstrip_last_line(content)
         return content
 
+    @property
+    def prefix(self):
+        return self.indent * self.level
+
     def render_comment(self):
         """Render a properly indented comment"""
-        prefix = self.indent * self.level
-        return "{prefix}<!--{text}-->".format(prefix=prefix, text=self.text)
+        return f"{self.prefix}<!--{self.text}-->"
 
     def render_doctype(self):
         """Render a properly indented comment"""
-        prefix = self.indent * self.level
-        return "{prefix}<!DOCTYPE {text}>".format(prefix=prefix, text=self.text)
+        return f"{self.prefix}<!DOCTYPE {self.text}>"
 
     def render_processing_instruction(self):
         """Render a properly indented processing instruction"""
-        prefix = self.indent * self.level
-        return "{prefix}<?{text}?>".format(prefix=prefix, text=self.text)
+        return f"{self.prefix}<?{self.text}?>"
 
     def render_text(self):
         """Render a properly indented text
@@ -246,11 +253,11 @@ class PrettyElement(object):
         If the text end with spaces, strip them.
         """
         text = self.text
-        lines = text.split(u"\n")
+        lines = text.split("\n")
         if not lines:
             return ""
 
-        prefix = self.indent * (self.level)
+        prefix = self.prefix
         if len(lines) == 1:
             line = lines[0]
             if not line.strip():
@@ -262,17 +269,17 @@ class PrettyElement(object):
             return line
 
         if not lines[0].strip():
-            rendered_lines = [u"\n"]
+            rendered_lines = ["\n"]
         elif startswith_whitespace(lines[0]):
-            rendered_lines = [u"\n" + prefix + "%s\n" % lines[0].rstrip()]
+            rendered_lines = ["\n" + prefix + "%s\n" % lines[0].rstrip()]
         else:
-            rendered_lines = [u"%s\n" % lines[0]]
+            rendered_lines = ["%s\n" % lines[0]]
 
         for line in lines[1:-1]:
             if not line.strip():
-                rendered_lines.append(u"\n")
+                rendered_lines.append("\n")
             else:
-                rendered_lines.append(u"%s\n" % line.rstrip())
+                rendered_lines.append("%s\n" % line.rstrip())
 
         if lines[-1].strip():
             if lines[-1].rstrip() == lines[-1]:
@@ -281,68 +288,40 @@ class PrettyElement(object):
                 else:
                     rendered_lines.append(prefix + lines[-1].lstrip())
             else:
-                rendered_lines.append(u"%s\n" % lines[-1].rstrip())
+                rendered_lines.append("%s\n" % lines[-1].rstrip())
         else:
-            rendered_lines.append(u"")
+            rendered_lines.append("")
         text = "".join(rendered_lines)
         return text
 
-    def attributes_prefix(self):
-        """Return the prefix for the attributes"""
-        if self.first_attribute_on_new_line:
-            return " " * 4
-        else:
-            return " " * (len(self.tag) + 2)
-
-    def indent_multiline_attributes(self, attributes):
-        """Indent the attributes to be rendered in a multiline tag"""
-        prefix = self.indent * self.level
-        attribute_line_joiner = "\n" + prefix + self.attributes_prefix()
-        attributes = attribute_line_joiner.join(attributes.splitlines())
-        if self.first_attribute_on_new_line:
-            # prepend a new line and the appropriate space
-            attributes = attribute_line_joiner + attributes
-        else:
-            attributes = " " + attributes
-        return attributes
-
-    def render_self_closing(self):
-        """Render a properly indented a self closing tag"""
-        attributes = self.attributes()
-        multiline_attributes = "\n" in attributes
-        if multiline_attributes:
-            attributes = self.indent_multiline_attributes(attributes)
-            template = self.self_closing_multiline_template
-        else:
-            if attributes:
-                # we need a space to separate the tag end
-                attributes = " " + attributes + " "
-            else:
-                attributes = " "
-            template = self.self_closing_singleline_template
-
-        prefix = self.indent * self.level
+    def _render_template(self, template):
         return template.format(
-            attributes=attributes,
             before_closing_multiline=self.before_closing_multiline,
-            prefix=prefix,
+            attributes=self.attributes.lstrip(),
+            prefix=self.prefix,
             tag=self.tag,
         )
 
+    def render_self_closing(self):
+        """Render a properly indented a self closing tag"""
+        attributes_len = len(self.attributes)
+        if attributes_len == 0:
+            template = self.self_closing_singleline_attributeless_template
+        elif attributes_len == 1:
+            template = self.self_closing_singleline_attributefull_template
+        else:
+            template = self.self_closing_multiline_template
+        return self._render_template(template)
+
     def render_not_self_closing(self):
         """Render a properly indented not self closing tag"""
-        attributes = self.attributes()
-        multiline_attributes = "\n" in attributes
-        if multiline_attributes:
-            attributes = self.indent_multiline_attributes(attributes)
-            open_tag_template = self.start_tag_multiline_template
+        attributes_len = len(self.attributes)
+        if attributes_len == 0:
+            open_tag_template = self.start_tag_singleline_attributeless_template
+        elif attributes_len == 1:
+            open_tag_template = self.start_tag_singleline_attributefull_template
         else:
-            if attributes:
-                # we need a space after separate from the tag
-                attributes = " " + attributes
-            open_tag_template = self.start_tag_singleline_template
-
-        prefix = self.indent * self.level
+            open_tag_template = self.start_tag_multiline_template
 
         text = self.text and self.render_text() or self.render_content()
 
@@ -353,13 +332,8 @@ class PrettyElement(object):
         else:
             close_tag_template = "</{tag}>"
 
-        open_tag = open_tag_template.format(
-            before_closing_multiline=self.before_closing_multiline,
-            attributes=attributes,
-            prefix=prefix,
-            tag=self.tag,
-        )
-        close_tag = close_tag_template.format(prefix=prefix, tag=self.tag)
+        open_tag = self._render_template(open_tag_template)
+        close_tag = self._render_template(close_tag_template)
         return "{open_tag}{text}{close_tag}".format(
             close_tag=close_tag, open_tag=open_tag, text=text
         )

--- a/zpretty/tests/original/sample_html.html
+++ b/zpretty/tests/original/sample_html.html
@@ -11,6 +11,11 @@
     <div></div><!-- -->
     <div class="b"
          id="a"
+         data-multiline="
+  foo
+    bar
+      baz
+        "
     >test
 
     </div><!-- #a -->

--- a/zpretty/tests/test_attributes.py
+++ b/zpretty/tests/test_attributes.py
@@ -1,21 +1,46 @@
+from bs4 import BeautifulSoup
 from unittest import TestCase
 from zpretty.attributes import PrettyAttributes
+from zpretty.elements import PrettyElement
 
 
 class TestZPrettyAttributess(TestCase):
     """Test zpretty"""
 
+    def get_element(self, text, level=0):
+        """Given a text return a PrettyElement"""
+        soup = BeautifulSoup(
+            "<soup><fake_root>%s</fake_root></soup>" % text, "html.parser"
+        )
+        return PrettyElement(soup.fake_root.next_element, level)
+
     def assertPrettifiedAttributes(self, attributes, expected, level=0):
         """Check if the attributes are properly sorted and formatted"""
-        pretty_attribute = PrettyAttributes(attributes)
+        if level == 0:
+            el = None
+        else:
+            el = self.get_element("a", level)
+        pretty_attribute = PrettyAttributes(attributes, el)
         observed = pretty_attribute()
         self.assertEqual(observed, expected)
 
     def test_no_attributes(self):
         self.assertPrettifiedAttributes({}, "")
+        self.assertPrettifiedAttributes({}, "", level=2)
 
     def test_one_attribute(self):
         self.assertPrettifiedAttributes({u"a": "1"}, 'a="1"')
+        self.assertPrettifiedAttributes({u"a": "1"}, 'a="1"', level=1)
+        self.assertPrettifiedAttributes({u"a": "1"}, 'a="1"', level=2)
+
+    def test_many_attributes_attribute(self):
+        self.assertPrettifiedAttributes({u"a": "1", u"b": "2"}, 'a="1"\nb="2"')
+        self.assertPrettifiedAttributes(
+            {u"a": "1", u"b": "2"}, '    a="1"\n    b="2"', level=1
+        )
+        self.assertPrettifiedAttributes(
+            {u"a": "1", u"b": "2"}, '      a="1"\n      b="2"', level=2
+        )
 
     def test_tal_define(self):
         self.assertPrettifiedAttributes(
@@ -25,12 +50,20 @@ class TestZPrettyAttributess(TestCase):
 
     def test_format_attributes_many_attribute(self):
         self.assertPrettifiedAttributes(
-            {u"a": "1", "b": "2", "class": "hidden", "tal:define": "a 1; b 2"},
+            {
+                u"a": "1",
+                "b": "2",
+                "class": "hidden",
+                "tal:define": "a 1; b 2",
+                "data-multiline": "foo\n   bar",
+            },
             "\n".join(
                 (
                     'class="hidden"',
                     'a="1"',
                     'b="2"',
+                    'data-multiline="foo',
+                    '   bar"',
                     'tal:define="',
                     "  a 1;",
                     "  b 2;",

--- a/zpretty/tests/test_elements.py
+++ b/zpretty/tests/test_elements.py
@@ -6,12 +6,12 @@ from zpretty.elements import PrettyElement
 class TestPrettyElements(TestCase):
     """Test basic funtionalities of the PrettyElement class"""
 
-    def get_element(self, text):
+    def get_element(self, text, level=0):
         """Given a text return a PrettyElement"""
         soup = BeautifulSoup(
             "<soup><fake_root>%s</fake_root></soup>" % text, "html.parser"
         )
-        return PrettyElement(soup.fake_root.next_element)
+        return PrettyElement(soup.fake_root.next_element, level)
 
     def test_comment(self):
         el = self.get_element("<!--a-->")

--- a/zpretty/tests/test_zcml.py
+++ b/zpretty/tests/test_zcml.py
@@ -1,5 +1,8 @@
+from bs4 import BeautifulSoup
 from pkg_resources import resource_filename
 from unittest import TestCase
+from zpretty.zcml import ZCMLAttributes
+from zpretty.zcml import ZCMLElement
 from zpretty.zcml import ZCMLPrettifier
 
 
@@ -7,6 +10,214 @@ class TestZpretty(TestCase):
     """Test zpretty"""
 
     maxDiff = None
+
+    def get_element(self, text, level=0):
+        """Given a text return a PrettyElement"""
+        soup = BeautifulSoup(
+            u"<soup><fake_root>%s</fake_root></soup>" % text, "html.parser"
+        )
+        return ZCMLElement(soup.fake_root.next_element, level)
+
+    def assertPrettifiedAttributes(self, attributes, expected, level=0):
+        """Check if the attributes are properly sorted and formatted"""
+        if level == 0:
+            el = None
+        else:
+            el = self.get_element("foo", level)
+        pretty_attribute = ZCMLAttributes(attributes, el)
+        observed = pretty_attribute()
+        self.assertEqual(observed, expected)
+
+    def test_zcml_attributes_no_attributes(self):
+        self.assertPrettifiedAttributes(ZCMLAttributes({})(), "")
+        self.assertPrettifiedAttributes({}, "", level=2)
+
+    def test_zcml_attributes_one_attributes(self):
+        self.assertPrettifiedAttributes({u"a": "1"}, 'a="1"')
+        self.assertPrettifiedAttributes({u"a": "1"}, 'a="1"', level=1)
+        self.assertPrettifiedAttributes({u"a": "1"}, 'a="1"', level=2)
+
+    def test_zcml_attributes_many_attributes(self):
+        self.assertPrettifiedAttributes({u"a": "1", u"b": "2"}, '    a="1"\n    b="2"')
+        self.assertPrettifiedAttributes(
+            {u"a": "1", u"b": "2"}, '      a="1"\n      b="2"', level=1
+        )
+        self.assertPrettifiedAttributes(
+            {u"a": "1", u"b": "2"}, '        a="1"\n        b="2"', level=2
+        )
+
+    def test_zcml_self_closing_no_attributes(self):
+        element = self.get_element("<zcml />")
+        self.assertEqual(element(), "<zcml />")
+        element = self.get_element("<zcml />", 1)
+        self.assertEqual(element(), "  <zcml />")
+        element = self.get_element("<zcml />", 2)
+        self.assertEqual(element(), "    <zcml />")
+
+    def test_zcml_self_closing_one_attributes(self):
+        element = self.get_element('<zcml \n foo="bar"/>')
+        self.assertEqual(element(), '<zcml foo="bar" />')
+        element = self.get_element('<zcml \n foo="bar"/>', 1)
+        self.assertEqual(element(), '  <zcml foo="bar" />')
+        element = self.get_element('<zcml \n foo="bar"/>', 2)
+        self.assertEqual(element(), '    <zcml foo="bar" />')
+
+    def test_zcml_self_closing_many_attributes(self):
+        element = self.get_element('<zcml \n foo="bar" bar="foo"/>')
+        self.assertEqual(
+            element(),
+            "\n".join(
+                (
+                    "<zcml",
+                    '    bar="foo"',
+                    '    foo="bar"',
+                    "    />",
+                )
+            ),
+        )
+        element = self.get_element('<zcml \n foo="bar" bar="foo"/>', 1)
+        self.assertEqual(
+            element(),
+            "\n".join(
+                (
+                    "  <zcml",
+                    '      bar="foo"',
+                    '      foo="bar"',
+                    "      />",
+                )
+            ),
+        )
+        element = self.get_element('<zcml \n foo="bar" bar="foo"/>', 2)
+        self.assertEqual(
+            element(),
+            "\n".join(
+                (
+                    "    <zcml",
+                    '        bar="foo"',
+                    '        foo="bar"',
+                    "        />",
+                )
+            ),
+        )
+
+    def test_for_attribute_single_attribute(self):
+        element = self.get_element('<zcml \n for="foo"/>')
+        self.assertEqual(element(), '<zcml for="foo" />')
+        element = self.get_element('<zcml \n for="foo"/>', 1)
+        self.assertEqual(element(), '  <zcml for="foo" />')
+        element = self.get_element('<zcml \n for="foo"/>', 2)
+        self.assertEqual(element(), '    <zcml for="foo" />')
+
+        element = self.get_element('<zcml \n for="foo bar"/>')
+        self.assertEqual(
+            element(),
+            "\n".join(
+                (
+                    '<zcml for="foo',
+                    '           bar" />',
+                )
+            ),
+        )
+
+        element = self.get_element('<zcml \n for="foo bar"/>', 1)
+        self.assertEqual(
+            element(),
+            "\n".join(
+                (
+                    '  <zcml for="foo',
+                    '             bar" />',
+                )
+            ),
+        )
+
+        element = self.get_element('<zcml \n for="foo bar"/>', 2)
+        self.assertEqual(
+            element(),
+            "\n".join(
+                (
+                    '    <zcml for="foo',
+                    '               bar" />',
+                )
+            ),
+        )
+
+    def test_for_attribute_multiple_attribute(self):
+        element = self.get_element('<zcml \n for="foo" handler="bar" />')
+        self.assertEqual(
+            element(),
+            "\n".join(
+                (
+                    "<zcml",
+                    '    for="foo"',
+                    '    handler="bar"',
+                    "    />",
+                )
+            ),
+        )
+        element = self.get_element('<zcml \n for="foo" handler="bar" />', 1)
+        self.assertEqual(
+            element(),
+            "\n".join(
+                (
+                    "  <zcml",
+                    '      for="foo"',
+                    '      handler="bar"',
+                    "      />",
+                )
+            ),
+        )
+        element = self.get_element('<zcml \n for="foo" handler="bar" />', 2)
+        self.assertEqual(
+            element(),
+            "\n".join(
+                (
+                    "    <zcml",
+                    '        for="foo"',
+                    '        handler="bar"',
+                    "        />",
+                )
+            ),
+        )
+
+        element = self.get_element('<zcml \n for="foo bar" handler="bar" />')
+        self.assertEqual(
+            element(),
+            "\n".join(
+                (
+                    "<zcml",
+                    '    for="foo',
+                    '         bar"',
+                    '    handler="bar"',
+                    "    />",
+                )
+            ),
+        )
+        element = self.get_element('<zcml \n for="foo bar" handler="bar" />', 1)
+        self.assertEqual(
+            element(),
+            "\n".join(
+                (
+                    "  <zcml",
+                    '      for="foo',
+                    '           bar"',
+                    '      handler="bar"',
+                    "      />",
+                )
+            ),
+        )
+        element = self.get_element('<zcml \n for="foo bar" handler="bar" />', 2)
+        self.assertEqual(
+            element(),
+            "\n".join(
+                (
+                    "    <zcml",
+                    '        for="foo',
+                    '             bar"',
+                    '        handler="bar"',
+                    "        />",
+                )
+            ),
+        )
 
     def prettify(self, filename):
         """Run prettify on filename and check that the output is equal to


### PR DESCRIPTION
The attributes renderer knows about the element indentation
and for indents the attributes consequently.
The ZCML element has now its custom tag templates, this simplifies the code
Attributes content spanning multiple lines is not indented anymore (Closes #17)