### PR TITLE
Do not render a spurious `=""` when new lines appear inside a tag

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 2.1.0 (unreleased)
 ------------------
 
+- Do not render a spurious `=""` when new lines appear inside a tag (Refs. #35) [ale-rt]
 - The attributes renderer knows about the element indentation
   and for indents the attributes consequently [ale-rt]
 - The ZCML element has now its custom tag templates, this simplifies the code [ale-rt]

--- a/zpretty/prettifier.py
+++ b/zpretty/prettifier.py
@@ -33,6 +33,11 @@ class ZPrettifier(object):
             for line in text.splitlines()
         )
         self.soup = self.get_soup(self.text)
+
+        # Cleanup all spurious self._newlines_marker attributes, see #35
+        for el in self.soup.find_all(attrs={self._newlines_marker: ""}):
+            el.attrs.pop(self._newlines_marker, None)
+
         self.root = self.pretty_element(self.soup, -1)
 
     def get_soup(self, text):

--- a/zpretty/tests/test_zpretty.py
+++ b/zpretty/tests/test_zpretty.py
@@ -152,6 +152,17 @@ class TestZpretty(TestCase):
             "<root>\n (<a></a>)\n</root>", "<root>\n  (<a></a>)\n</root>\n"
         )
 
+    def test_elements_with_new_lines(self):
+        self.assertPrettified("<root\n></root>", "<root></root>\n")
+        self.assertPrettified(
+            '<root\na="b"\n\n></root>',
+            ('<root a="b"></root>\n'),
+        )
+        self.assertPrettified(
+            '<root\na="b"\n\nc="d"></root>',
+            ('<root a="b"\n      c="d"\n></root>\n'),
+        )
+
     def test_entities(self):
         self.assertPrettified("<root>&nbsp;</root>", "<root>&nbsp;</root>\n")
 


### PR DESCRIPTION
Fixes #35