### PR TITLE
Preserve whitespace in XML documents and `pre` elements

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 2.2.1 (unreleased)
 ------------------
 
+- Preserve whitespace in XML documents and `pre` elements (Fixes #64) [ale-rt]
 - Improve doctype handling [ale-rt]
 - Do not kill XML documents with a doctype (Fixes #47) [ale-rt]
 - Support Python 3.10 [ale-rt]

--- a/zpretty/tests/original/sample_html.html
+++ b/zpretty/tests/original/sample_html.html
@@ -47,6 +47,8 @@
       Sorry, your browser doesn't support embedded videos.
     </video>
 
+    <pre> </pre>
+
     <tal:example>
       <p>
         Inside a tal!

--- a/zpretty/tests/original/sample_pt.pt
+++ b/zpretty/tests/original/sample_pt.pt
@@ -18,6 +18,10 @@
            href="#"
         >whatever</b>
         "<c href="#">whatever</c>"
+        <pre>
+          Foo
+            Bar
+        </pre>
       </metal:content-core>
     </metal:main>
   </body>

--- a/zpretty/tests/original/sample_xml.xml
+++ b/zpretty/tests/original/sample_xml.xml
@@ -2,5 +2,9 @@
 <root>
   <pretty a="b">1</pretty>
   <closeme hidden="" />
+  <preserve_space> </preserve_space>
+  <preserve_space>
+
+      </preserve_space>
   <fòò attribute="bàr">bàz</fòò>
 </root>

--- a/zpretty/xml.py
+++ b/zpretty/xml.py
@@ -9,6 +9,11 @@ from zpretty.prettifier import ZPrettifier
 logger = getLogger(__name__)
 
 
+class AnyIn(object):
+    def __contains__(self, item):
+        return True
+
+
 class XMLAttributes(PrettyAttributes):
     """Customized attribute formatter for zcml"""
 
@@ -27,6 +32,7 @@ class XMLAttributes(PrettyAttributes):
 class XMLElement(PrettyElement):
     attribute_klass = XMLAttributes
     escaper = None
+    preserve_text_whitespace_elements = AnyIn()
 
     def is_self_closing(self):
         """Is this element self closing?"""


### PR DESCRIPTION
Fixes #64