### PR TITLE
CDATA support for XML

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Basic usage:
 ```console
 $ zpretty -h
 usage: zpretty [-h] [--encoding ENCODING] [-i] [-v] [-x] [-z] [--check]
+               [--cdata]
                [file ...]
 
 positional arguments:
@@ -76,6 +77,7 @@ options:
                         styleguide
     --check              Return code 0 if nothing would be changed, 1 if some
                         files would be reformatted
+    --cdata              Preserve CDATA tags in XML files
 ```
 
 Without parameters constraining the file type (e.g. `-x`, `-z`, \...)

--- a/zpretty/cli.py
+++ b/zpretty/cli.py
@@ -74,6 +74,13 @@ def get_parser():
         default=False,
     )
     parser.add_argument(
+        "--cdata",
+        help="Preserve CDATA tags in XML files",
+        action="store_true",
+        dest="cdata",
+        default=False,
+    )
+    parser.add_argument(
         "file",
         nargs="*",
         default="-",
@@ -103,7 +110,7 @@ def run():
     encoding = config.encoding
     for infile in config.file:
         Prettifier = choose_prettifier(config, infile)
-        prettifier = Prettifier(infile, encoding=encoding)
+        prettifier = Prettifier(infile, encoding=encoding, cdata=config.cdata)
         if config.check:
             if not prettifier.check():
                 stderr.write(f"This file would be rewritten: {infile}\n")

--- a/zpretty/prettifier.py
+++ b/zpretty/prettifier.py
@@ -21,12 +21,15 @@ class ZPrettifier(object):
     _newlines_marker = str(uuid4())
     _ampersand_marker = str(uuid4())
 
-    def __init__(self, filename="", text="", encoding="utf8"):
+    def __init__(self, filename="", text="", encoding="utf8", cdata=False):
         """Create a prettifier instance taking the contents
         from a text or a filename
         """
         self.encoding = encoding
         self.filename = filename
+        self.cdata = cdata
+        if self.cdata:
+            self.parser = "html.parser"
         if self.filename:
             text = "".join(fileinput.input([filename]))
         if not isinstance(text, str):

--- a/zpretty/tests/original/sample_cdata.xml
+++ b/zpretty/tests/original/sample_cdata.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <pretty a="b">1</pretty>
+  <closeme hidden="" />
+  <preserve_space> </preserve_space>
+  <preserve_space>
+
+      </preserve_space>
+  <fòò attribute="bàr">bàz</fòò>
+  <property name="model_source">&lt;model&quot;teste&lt;/model&gt;</property>
+  <property bar="&quot;"
+            foo="&amp;"
+  ><![CDATA[Top Level Container f&uuml;r alle Reviere]]></property>
+</root>

--- a/zpretty/tests/test_cli.py
+++ b/zpretty/tests/test_cli.py
@@ -27,7 +27,7 @@ class TestCli(TestCase):
         self.assertTrue(all((parsed.inplace, parsed.xml, parsed.zcml)))
 
     def test_long_options(self):
-        parsed = self.parser.parse_args(["--inplace", "--xml", "--zcml"])
+        parsed = self.parser.parse_args(["--inplace", "--xml", "--zcml", "--cdata"])
         self.assertTrue(all((parsed.inplace, parsed.xml, parsed.zcml)))
 
     def test_file(self):
@@ -54,6 +54,12 @@ class TestCli(TestCase):
     def test_check(self):
         parsed = self.parser.parse_args(["--check"])
         self.assertTrue(parsed.check)
+
+    def test_cdata(self):
+        parsed = self.parser.parse_args([])
+        self.assertFalse(parsed.cdata)
+        parsed = self.parser.parse_args(["--cdata"])
+        self.assertTrue(parsed.cdata)
 
     def test_run(self):
         # XXX increase coverage by improving the mock

--- a/zpretty/tests/test_xml.py
+++ b/zpretty/tests/test_xml.py
@@ -8,18 +8,21 @@ class TestZpretty(TestCase):
 
     maxDiff = None
 
-    def prettify(self, filename):
+    def prettify(self, filename, cdata):
         """Run prettify on filename and check that the output is equal to
         the file content itself
         """
         resolved_filename = resource_filename("zpretty.tests", "original/%s" % filename)
-        prettifier = XMLPrettifier(resolved_filename)
+        prettifier = XMLPrettifier(resolved_filename, cdata=cdata)
         observed = prettifier()
         expected = open(resolved_filename).read()
         self.assertListEqual(observed.splitlines(), expected.splitlines())
 
     def test_zcml(self):
-        self.prettify("sample_xml.xml")
+        self.prettify("sample_xml.xml", False)
 
     def test_sample_dtml(self):
-        self.prettify("sample_dtml.dtml")
+        self.prettify("sample_dtml.dtml", False)
+
+    def test_cdata(self):
+        self.prettify("sample_cdata.xml", True)

--- a/zpretty/xml.py
+++ b/zpretty/xml.py
@@ -1,5 +1,5 @@
 from bs4 import BeautifulSoup
-from bs4.element import NavigableString
+from bs4.element import CData, NavigableString
 from logging import getLogger
 from zpretty.attributes import PrettyAttributes
 from zpretty.elements import PrettyElement
@@ -54,6 +54,8 @@ class XMLElement(PrettyElement):
 
         Convert the text characters to html entities
         """
+        if isinstance(self.context, CData):
+            return f"<![CDATA[{self.context}]]>"
         if not isinstance(self.context, NavigableString):
             return ""
         if self.is_comment():


### PR DESCRIPTION
Hi,

Please see my initial version for CDATA tag support for XML files. It adds the long option `--cdata`.
By default, nothing has changed.
Only if you specify the `--cdata` option and parse an XML file containing CDATA tags, then the CDATA tags will remain unchanged. Without the `--cdata` option, the CDATA tags are removed (which is now the default).

See #76 for the initial request.

Thanks for your consideration!