### PR TITLE
Do not try to do anything on CDATAs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,7 +3,8 @@
 2.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Do not try to do anything on CDATAs (Fixes #76)
+  [ale-rt]
 
 
 2.3.0 (2022-09-26)

--- a/zpretty/tests/original/sample_html.html
+++ b/zpretty/tests/original/sample_html.html
@@ -24,6 +24,7 @@
         content: " <&";
       }
     </style>
+        <![CDATA[ <>& ]]>
   </head>
   <body>
     <div class="hero"></div>
@@ -87,6 +88,15 @@
     <input name="search"
            type="text"
     />
+    <![CDATA[
+      This
+        should
+          be
+
+            preserved
+              as
+                is
+  ]]>
     <ul><li><a></a></li></ul>
   </div>
 </html>

--- a/zpretty/tests/original/sample_pt.pt
+++ b/zpretty/tests/original/sample_pt.pt
@@ -6,7 +6,7 @@
       metal:use-macro="context/@@main_template/macros/master"
       xml:lang="en"
       i18n:domain="plone"
->
+><![CDATA[ <>& ]]>
   <body>
     <metal:main fill-slot="content-core">
       <metal:content-core define-macro="content-core">
@@ -24,5 +24,14 @@
         </pre>
       </metal:content-core>
     </metal:main>
+    <![CDATA[
+      This
+        should
+          be
+
+            preserved
+              as
+                is
+  ]]>
   </body>
 </html>

--- a/zpretty/tests/original/sample_xml.xml
+++ b/zpretty/tests/original/sample_xml.xml
@@ -6,9 +6,21 @@
   <preserve_space>
 
       </preserve_space>
+  <cdata><![CDATA[ <>& ]]>
+
+  </cdata>
   <fòò attribute="bàr">bàz</fòò>
   <property name="model_source">&lt;model&quot;teste&lt;/model&gt;</property>
   <property bar="&quot;"
             foo="&amp;"
   >Top Level Container f&uuml;r alle Reviere</property>
+  <![CDATA[
+      This
+        should
+          be
+
+            preserved
+              as
+                is
+  ]]>
 </root>


### PR DESCRIPTION
By default the BeautifulSoup parser will strip the CDATAs. To prevent that and prevent that zpretty tampers with the content of a CDATA sections, they are replaced before parsing the document and restored afterwards as they were originally coded.

Fixes #76