### PR TITLE
Do not tamper attributes in XML

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,7 +3,9 @@
 2.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Do not tamper attributes in XML as if they were a page template attribute
+  (Fixes #85)
+  [ale-rt]
 
 
 2.4.0 (2022-10-22)

--- a/zpretty/tests/original/sample_xml.xml
+++ b/zpretty/tests/original/sample_xml.xml
@@ -15,7 +15,8 @@
   </cdata>
   <fòò attribute="bàr">bàz</fòò>
   <property name="model_source">&lt;model&quot;teste&lt;/model&gt;</property>
-  <property bar="&quot;"
+  <property attributes="*"
+            bar="&quot;"
             foo="&amp;"
   >Top Level Container f&uuml;r alle Reviere</property>
   <![CDATA[

--- a/zpretty/xml.py
+++ b/zpretty/xml.py
@@ -20,7 +20,9 @@ class XMLAttributes(PrettyAttributes):
     _boolean_attributes_are_allowed = False
     _known_boolean_attributes = ()
     _multiline_attributes = ()
+    _tal_multiline_attributes = ()
     _xml_attribute_order = ()
+    _tal_attribute_order = ()
 
     def sort_attributes(self, name):
         """Sort ZCML attributes in a consistent way"""


### PR DESCRIPTION
Do not tamper attributes in XML as if they were a page template attribute

Fixes #85