### PR TITLE
XML files with newlines between attributes are properly formatted

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,9 @@
 2.4.1 (unreleased)
 ------------------
 
+- XML files with newlines between attributes are properly formatted
+  (Fixes #84)
+  [ale-rt]
 - Do not tamper attributes in XML as if they were a page template attribute
   (Fixes #85)
   [ale-rt]

--- a/zpretty/prettifier.py
+++ b/zpretty/prettifier.py
@@ -19,7 +19,7 @@ class ZPrettifier(object):
     parser = "html.parser"
     builder = None
     _end_with_newline = True
-    _newlines_marker = str(uuid4())
+    _newlines_marker = f'new-line-{str(uuid4())}=""'
     _ampersand_marker = str(uuid4())
     _cdata_marker = str(uuid4())
     _cdata_pattern = re.compile(r"<!\[CDATA\[(.*?)\]\]>", re.DOTALL)
@@ -45,8 +45,9 @@ class ZPrettifier(object):
         self.soup = self.get_soup(self.text)
 
         # Cleanup all spurious self._newlines_marker attributes, see #35
-        for el in self.soup.find_all(attrs={self._newlines_marker: ""}):
-            el.attrs.pop(self._newlines_marker, None)
+        key = self._newlines_marker.partition("=")[0]
+        for el in self.soup.find_all(attrs={key: ""}):
+            el.attrs.pop(key, None)
 
         self.root = self.pretty_element(self.soup, -1)
 

--- a/zpretty/tests/test_xml.py
+++ b/zpretty/tests/test_xml.py
@@ -1,5 +1,7 @@
+from bs4 import BeautifulSoup
 from pkg_resources import resource_filename
 from unittest import TestCase
+from zpretty.xml import XMLElement
 from zpretty.xml import XMLPrettifier
 
 
@@ -7,6 +9,13 @@ class TestZpretty(TestCase):
     """Test zpretty"""
 
     maxDiff = None
+
+    def get_element(self, text, level=0):
+        """Given a text return a XMLElement"""
+        soup = BeautifulSoup(
+            "<soup><fake_root>%s</fake_root></soup>" % text, "html.parser"
+        )
+        return XMLElement(soup.fake_root.next_element, level)
 
     def prettify(self, filename):
         """Run prettify on filename and check that the output is equal to
@@ -17,6 +26,11 @@ class TestZpretty(TestCase):
         observed = prettifier()
         expected = open(resolved_filename).read()
         self.assertListEqual(observed.splitlines(), expected.splitlines())
+
+    def test_newline_between_attributes(self):
+        """See #84"""
+        element = self.get_element('<one \n foo="bar"\n\n\nbar="foo"\n/>')
+        self.assertEqual(element(), '<one bar="foo"\n     foo="bar"\n/>')
 
     def test_zcml(self):
         self.prettify("sample_xml.xml")


### PR DESCRIPTION
Fixes #84