### PR TITLE
Fix error with text input

### DIFF
--- a/zpretty/prettifier.py
+++ b/zpretty/prettifier.py
@@ -112,4 +112,7 @@ class ZPrettifier(object):
         return self.original_text == self()
 
     def __call__(self):
+        if not self.root.getchildren():
+            # The parsed content is not even something that looks like an XML
+            return self.original_text
         return self.pretty_print(self.root)

--- a/zpretty/tests/original/sample.txt
+++ b/zpretty/tests/original/sample.txt
@@ -1,0 +1,1 @@
+This is a text file and should not be touched!

--- a/zpretty/tests/test_xml.py
+++ b/zpretty/tests/test_xml.py
@@ -37,3 +37,6 @@ class TestZpretty(TestCase):
 
     def test_sample_dtml(self):
         self.prettify("sample_dtml.dtml")
+
+    def test_sample_txt(self):
+        self.prettify("sample.txt")

--- a/zpretty/tests/test_zpretty.py
+++ b/zpretty/tests/test_zpretty.py
@@ -182,3 +182,6 @@ class TestZpretty(TestCase):
 
     def test_text_with_markup(self):
         self.prettify("text_with_markup.md")
+
+    def test_text_file(self):
+        self.prettify("sample.txt")


### PR DESCRIPTION
Before
```shell
$ git ls-files "*.dkjsdksj" |xargs zpretty -x
Traceback (most recent call last):
  File "/home/ale/.local/bin/zpretty", line 8, in <module>
    sys.exit(run())
  File "/home/ale/.local/pipx/venvs/zpretty/lib/python3.10/site-packages/zpretty/cli.py", line 112, in run
    prettified = prettifier()
  File "/home/ale/.local/pipx/venvs/zpretty/lib/python3.10/site-packages/zpretty/prettifier.py", line 118, in __call__
    return self.pretty_print(self.root)
  File "/home/ale/.local/pipx/venvs/zpretty/lib/python3.10/site-packages/zpretty/prettifier.py", line 99, in pretty_print
    el().replace(self._newlines_marker, "").replace(self._ampersand_marker, "&")
  File "/home/ale/.local/pipx/venvs/zpretty/lib/python3.10/site-packages/zpretty/elements.py", line 32, in wrapped
    setattr(obj, key, f(obj))
  File "/home/ale/.local/pipx/venvs/zpretty/lib/python3.10/site-packages/zpretty/elements.py", line 379, in __call__
    return self.render_soup()
  File "/home/ale/.local/pipx/venvs/zpretty/lib/python3.10/site-packages/zpretty/elements.py", line 278, in render_soup
    first_child = next(self.context.children)
StopIteration
```

After:
```
$ git ls-files "*.dkjsdksj" |xargs zpretty -x
```