### PR TITLE
Fix a deprecation warning

### DIFF
--- a/zpretty/tests/test_readme.py
+++ b/zpretty/tests/test_readme.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from pkg_resources import resource_filename
 from unittest import TestCase
 from zpretty.tests.mock import MockCLIRunner
@@ -13,7 +14,7 @@ class TestReadme(TestCase):
 
     def extract_usage_from_readme(self):
         """Extract the usage from the documentation"""
-        resolved_filename = resource_filename("zpretty", "../README.md")
+        resolved_filename = Path(resource_filename("zpretty", ".")) / ".." / "README.md"
 
         with open(resolved_filename) as f:
             readme = f.read()


### PR DESCRIPTION
```
zpretty/tests/test_readme.py::TestReadme::test_readme
    .../python3.11/site-packages/pkg_resources/__init__.py:1201: DeprecationWarning: Use of .. or absolute path in a resource path is not allowed and will raise exceptions in a future release.
    return get_provider(package_or_requirement).get_resource_filename(
```