### PR TITLE
When parsing XML files, preserve space in all the tags

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,9 @@
 
 ## 3.2.0 (unreleased)
 
+- When parsing XML files, preserve space in all the tags
+  (Fixes #169)
+  [ale-rt]
 - Declare support for Python 3.13
   [ale-rt]
 

--- a/zpretty/tests/original/sample_xml.xml
+++ b/zpretty/tests/original/sample_xml.xml
@@ -8,8 +8,16 @@
   <closeme hidden="" />
   <preserve_space> </preserve_space>
   <preserve_space>
+  </preserve_space>
+
+  <preserve_space>
 
       </preserve_space>
+
+  <preserve_space_with_content>
+    <foo>bar</foo>
+  </preserve_space_with_content>
+
   <cdata><![CDATA[ <>& ]]>
 
   </cdata>

--- a/zpretty/xml.py
+++ b/zpretty/xml.py
@@ -1,4 +1,5 @@
 from bs4 import BeautifulSoup
+from bs4.builder import LXMLTreeBuilderForXML
 from bs4.element import NavigableString
 from logging import getLogger
 from zpretty.attributes import PrettyAttributes
@@ -74,7 +75,11 @@ class XMLPrettifier(ZPrettifier):
 
         If the text is not some xml like think a dummy element will be used to wrap it.
         """
-        original_soup = BeautifulSoup(text, self.parser)
+        original_soup = BeautifulSoup(
+            text,
+            self.parser,
+            builder=LXMLTreeBuilderForXML(preserve_whitespace_tags=AnyIn()),
+        )
         if original_soup.is_xml:
             return original_soup
 


### PR DESCRIPTION
Fixes #169