### PR TITLE
Attribute keep line breaks

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,8 +2,10 @@
 
 ## 4.0.1 (unreleased)
 
-
-- Nothing changed yet.
+- keep line breaks: Do not reformat class attribute values.
+  This allows for multi-line or otherwise manually strangely formatted
+  class attributes.
+  [thet]
 
 
 ## 4.0.0 (2026-04-10)

--- a/zpretty/attributes.py
+++ b/zpretty/attributes.py
@@ -115,7 +115,8 @@ class PrettyAttributes:
         """
         if name.startswith("xmlns"):
             return (0, name)
-        if name in ("class", "id"):
+        # data-zpretty-class being the class replacement to avoid reformatting.
+        if name in ("class", "data-zpretty-class", "id"):
             return (100, name)
         if name.startswith("data"):
             return (300, name)

--- a/zpretty/prettifier.py
+++ b/zpretty/prettifier.py
@@ -23,6 +23,9 @@ class ZPrettifier:
     _ampersand_marker = str(uuid4())
     _cdata_marker = str(uuid4())
     _cdata_pattern = re.compile(r"<!\[CDATA\[(.*?)\]\]>", re.DOTALL)
+    _class_marker_name = "data-zpretty-class"
+    _class_marker = " data-zpretty-class="
+    _class_pattern = " class="
     _doctype_marker = f"<!DOCTYPE foo-{str(uuid4())}>"
     _doctype_pattern = re.compile(
         r"(<!DOCTYPE[^>[]*(\[[^]]*\])?>)", re.IGNORECASE | re.DOTALL
@@ -50,6 +53,14 @@ class ZPrettifier:
         # in the attributes so that bogus ones can be escaped
         for el in soup.descendants:
             attrs = getattr(el, "attrs", {})
+
+            # Restore class attributes.
+            # Beautiful soup changes the formatting of class attributes into a
+            # single-line attribute.
+            if self._class_marker_name in attrs:
+                attrs["class"] = attrs.get(self._class_marker_name)
+                del attrs[self._class_marker_name]
+
             for key, value in attrs.items():
                 if self._ampersand_marker in value:
                     attrs[key] = value.replace(self._ampersand_marker, "&")
@@ -121,6 +132,11 @@ class ZPrettifier:
             pass
         text = re.sub(self._cdata_pattern, self._cdata_marker, text)
         text = re.sub(self._doctype_pattern, self._doctype_marker, text)
+
+        # Replace class attributes.
+        # Beautiful soup changes the formatting of class attributes into a
+        # single-line attribute, which we want to prevent.
+        text = re.sub(self._class_pattern, self._class_marker, text)
 
         # Get all the entities in the text and replace them with a marker
         # The text might contain undefined entities that BeautifulSoup

--- a/zpretty/tests/original/sample_pt.pt
+++ b/zpretty/tests/original/sample_pt.pt
@@ -47,6 +47,17 @@
                  ${'class-d' if True else ''}
                  button button-important
                  pil pil-${'blue' if True else ''}
+
+                 pat-inject
+               "
+               data-pat-inject="
+                  source: .main-content .important-stuff;
+                  target: .class-b .target
+                  &amp;&amp;
+                  source: .header #logo;
+                  target: .logo;
+                  ${'add: class-d' if True else ''}
+                  history:;
                "
           >
            okay

--- a/zpretty/tests/original/sample_pt.pt
+++ b/zpretty/tests/original/sample_pt.pt
@@ -39,6 +39,19 @@
           Foo
             Bar
         </pre>
+        <section class="class-a">
+          <div class="
+                 class-b
+                 class-c
+
+                 ${'class-d' if True else ''}
+                 button button-important
+                 pil pil-${'blue' if True else ''}
+               "
+          >
+           okay
+          </div>
+        </section>
         <form action="#"
               method="post"
         >


### PR DESCRIPTION
keep line breaks: Do not reformat class attribute values.
This allows for multi-line or otherwise manually strangely formatted
class attributes.

data-pat-* attributes are already kept.

This PR potentially replaces:
https://github.com/collective/zpretty/pull/213
https://github.com/collective/zpretty/pull/212
https://github.com/collective/zpretty/pull/211

 But this does not allow for automatic multiline-formatting. So data-pat-* attributes values and class attributes are not split one-by-line. They just keep the formatting they already have.