### PR TITLE
Fix some attributes whitespaces that were removed

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,8 +2,8 @@
 
 ## 4.0.1 (unreleased)
 
-
-- Nothing changed yet.
+- Do not considere any attribute multiline,
+  so that we can preserve whitespaces if desired. @ale-rt, @thet
 
 
 ## 4.0.0 (2026-04-10)

--- a/zpretty/prettifier.py
+++ b/zpretty/prettifier.py
@@ -69,6 +69,17 @@ class ZPrettifier:
 
         self.root = self.pretty_element(self.soup, -1)
 
+    def text2soup(self, text):
+        """Build a BeautifulSoup object preserving raw attribute values.
+
+        In particular, avoid splitting multi-valued attributes like ``class``
+        into lists so original whitespace/newlines can be preserved.
+        """
+        kwargs = {"multi_valued_attributes": None}
+        if self.builder is not None:
+            kwargs["builder"] = self.builder
+        return BeautifulSoup(text, self.parser, **kwargs)
+
     def fix_rcdata_markup(self, soup):
         """Parse markup-like text inside RCDATA tags as child nodes.
 
@@ -87,9 +98,8 @@ class ZPrettifier:
             raw_content = "".join(str(node) for node in tag.contents)
 
             null_tag_name = self.pretty_element.null_tag_name
-            fragment_soup = BeautifulSoup(
+            fragment_soup = self.text2soup(
                 f"<{null_tag_name}>{raw_content}</{null_tag_name}>",
-                self.parser,
             )
             fragment_root = getattr(fragment_soup, null_tag_name, None)
             if not fragment_root:
@@ -145,7 +155,7 @@ class ZPrettifier:
 
         If the text is not some xml like think a dummy element will be used to wrap it.
         """
-        original_soup = BeautifulSoup(text, self.parser)
+        original_soup = self.text2soup(text)
         try:
             first_el = next(original_soup.children)
         except StopIteration:
@@ -156,7 +166,7 @@ class ZPrettifier:
         markup = "<{null}>{text}</{null}>".format(
             null=self.pretty_element.null_tag_name, text=text
         )
-        wrapped_soup = BeautifulSoup(markup, self.parser)
+        wrapped_soup = self.text2soup(markup)
         return getattr(wrapped_soup, self.pretty_element.null_tag_name)
 
     def pretty_print(self, el):

--- a/zpretty/tests/original/sample_html.html
+++ b/zpretty/tests/original/sample_html.html
@@ -70,6 +70,31 @@
 
     <pre> </pre>
 
+    <section class="class-a">
+      <div class="
+             class-b
+             class-c
+
+             ${'class-d' if True else ''}
+             button button-important
+             pil pil-${'blue' if True else ''}
+
+             pat-inject
+           "
+           data-pat-inject="
+             source: .main-content .important-stuff;
+             target: .class-b .target
+             &amp;&amp;
+             source: .header #logo;
+             target: .logo;
+             ${'add: class-d' if True else ''}
+             history:;
+           "
+      >
+           okay
+      </div>
+    </section>
+
     <tal:example>
       <p>
         Inside a tal!

--- a/zpretty/tests/original/sample_pt.pt
+++ b/zpretty/tests/original/sample_pt.pt
@@ -39,6 +39,30 @@
           Foo
             Bar
         </pre>
+        <section class="class-a">
+          <div class="
+                 class-b
+                 class-c
+
+                 ${'class-d' if True else ''}
+                 button button-important
+                 pil pil-${'blue' if True else ''}
+
+                 pat-inject
+               "
+               data-pat-inject="
+                 source: .main-content .important-stuff;
+                 target: .class-b .target
+                 &amp;&amp;
+                 source: .header #logo;
+                 target: .logo;
+                 ${'add: class-d' if True else ''}
+                 history:;
+               "
+          >
+           okay
+          </div>
+        </section>
         <form action="#"
               method="post"
         >


### PR DESCRIPTION
This was caused by a BeautifulSoup configuration default that caused some attributes to be stored as a list of strings. The PR forces all attributes to be stored as string.

Refs. https://github.com/collective/zpretty/pull/216