### PR TITLE
fix: keep the XML root element when the prolog contains a blank line

### DIFF
--- a/zpretty/prettifier.py
+++ b/zpretty/prettifier.py
@@ -20,6 +20,10 @@ class ZPrettifier:
     builder = None
     _end_with_newline = True
     _newlines_marker = f"new-line-{str(uuid4())}"
+    # Replace blank lines with _newlines_marker before parsing so they survive the
+    # round-trip. Disabled for the xml parser, where it would corrupt the prolog
+    # (see _prepare_text and XMLPrettifier).
+    _use_newlines_marker = True
     _ampersand_marker = str(uuid4())
     _cdata_marker = str(uuid4())
     _cdata_pattern = re.compile(r"<!\[CDATA\[(.*?)\]\]>", re.DOTALL)
@@ -145,10 +149,12 @@ class ZPrettifier:
             marker = str(uuid4())
             self._entity_mapping[entity] = marker
             text = text.replace(entity, marker)
-        return "\n".join(
-            line if line.strip() else self._newlines_marker
-            for line in text.splitlines()
-        ).replace("&", self._ampersand_marker)
+        if self._use_newlines_marker:
+            text = "\n".join(
+                line if line.strip() else self._newlines_marker
+                for line in text.splitlines()
+            )
+        return text.replace("&", self._ampersand_marker)
 
     def get_soup(self, text):
         """Tries to get the soup from the given test

--- a/zpretty/tests/test_xml.py
+++ b/zpretty/tests/test_xml.py
@@ -48,3 +48,20 @@ class TestZpretty(TestCase):
 
     def test_sample_txt(self):
         self.prettify("sample.txt")
+
+    def test_prolog_blank_line_keeps_root(self):
+        """A blank line in the prolog must not make the parser drop the root.
+
+        Regression test: ``_prepare_text`` used to replace the blank line with a
+        marker that became illegal character data in the prolog, so the
+        recover-mode xml parser silently dropped the root element (data loss).
+        """
+        text = (
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            "<!-- a prolog comment -->\n"
+            "\n"
+            "<root><child>content</child></root>\n"
+        )
+        output = XMLPrettifier(text=text)()
+        self.assertIn("<root>", output)
+        self.assertIn("<child>content</child>", output)

--- a/zpretty/xml.py
+++ b/zpretty/xml.py
@@ -68,6 +68,11 @@ class XMLPrettifier(ZPrettifier):
 
     parser = "xml"
     pretty_element = XMLElement
+    # The xml builder preserves whitespace (preserve_whitespace_tags=AnyIn()), so
+    # the blank-line marker is unnecessary here; worse, a blank line in the prolog
+    # would become character data outside the root element and make the
+    # recover-mode parser silently drop the root. Keep real blank lines instead.
+    _use_newlines_marker = False
 
     def get_soup(self, text):
         """Tries to get the soup from the given test

--- a/zpretty/zcml.py
+++ b/zpretty/zcml.py
@@ -569,6 +569,10 @@ class ZCMLPrettifier(XMLPrettifier):
     """Prettify according to the ZCML style guide"""
 
     pretty_element = ZCMLElement
+    # ZCMLPrettifier wraps the input in a synthetic root (see get_soup), so it has
+    # no prolog and the blank-line marker is safe -- and needed to preserve blank
+    # lines between directives. Re-enable what XMLPrettifier turned off.
+    _use_newlines_marker = True
 
     def get_soup(self, text):
         """Tries to get the soup from the given text"""


### PR DESCRIPTION
zpretty silently drops the root element (and all its children) from a **valid** XML document when there's a blank line in the prolog — typically the blank line between a leading comment and the root. It exits `0`, and with `-i` it overwrites the file with the truncated stub.

```console
$ printf '<?xml version="1.0"?>\n<!-- c -->\n\n<root><child>x</child></root>\n' > repro.xml
$ zpretty repro.xml        # emits only the declaration + comment; <root> is gone, exit 0
```

### Cause

`_prepare_text()` rewrites every blank line to a `new-line-<uuid>` marker; in the prolog that becomes illegal character data, so the recover-mode lxml parser drops the root. The XML builder already preserves whitespace, so the marker is unnecessary for XML — this gates it behind a `_use_newlines_marker` flag, disabled for `XMLPrettifier`. `ZCMLPrettifier` keeps it (it wraps input → no prolog). Adds a regression test.