### PR TITLE
fix: keep inline elements in the text flow for XML mixed content

### DIFF
--- a/zpretty/elements.py
+++ b/zpretty/elements.py
@@ -232,12 +232,30 @@ class PrettyElement:
     @property
     @memo
     def preserve_text_whitespace(self):
+        if self.tag not in self.preserve_text_whitespace_elements:
+            return False
         children = self.getchildren()
-        return (
-            self.tag in self.preserve_text_whitespace_elements
-            and len(children) == 1
-            and children[0].is_text()
-        )
+        # A single text child is preserved verbatim, e.g. <pre>...</pre>.
+        if len(children) == 1 and children[0].is_text():
+            return True
+        # Mixed content: real prose text interspersed with inline elements,
+        # e.g. <p>see <link/> here</p>. Preserve the original flow instead of
+        # reflowing each child onto its own line. Content that is only child
+        # elements separated by whitespace (or blank-line markers) still
+        # reflows as block.
+        if not any(child.is_tag() for child in children):
+            return False
+        return any(self._carries_prose_text(child) for child in children)
+
+    def _carries_prose_text(self, child):
+        """Whether child is a text node with real prose, ignoring whitespace
+        and the internal blank-line marker (which stands in for an empty line,
+        not content)."""
+        if not child.is_text():
+            return False
+        from zpretty.prettifier import ZPrettifier
+
+        return bool(child.text.replace(ZPrettifier._newlines_marker, "").strip())
 
     @memo
     def render_content(self):
@@ -246,8 +264,15 @@ class PrettyElement:
         previous_part = ""
 
         if self.preserve_text_whitespace:
+            preserved = []
             for child in self.getchildren():
-                return child.text
+                if child.is_text():
+                    preserved.append(child.text)
+                else:
+                    # Render inline elements without their leading indent so
+                    # they stay within the surrounding text flow.
+                    preserved.append(child().lstrip())
+            return "".join(preserved)
 
         for idx, child in enumerate(self.getchildren()):
             part = child()

--- a/zpretty/tests/original/sample_mixed_content.xml
+++ b/zpretty/tests/original/sample_mixed_content.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<recipe>
+  <section>
+    <title>Ingredients at a glance</title>
+    <p>This <cake_name /> uses <ingredient_count /> ingredients and serves <servings /> people.</p>
+    <p>Before you begin, line a tin and <todo desc="note any prep step" />.</p>
+    <p>See the <a href="#method">full method</a> for the baking times.</p>
+  </section>
+</recipe>

--- a/zpretty/tests/test_xml.py
+++ b/zpretty/tests/test_xml.py
@@ -48,3 +48,56 @@ class TestZpretty(TestCase):
 
     def test_sample_txt(self):
         self.prettify("sample.txt")
+
+    def test_sample_mixed_content(self):
+        """Full-document idempotency for prose with inline elements.
+
+        On master this fixture is reflowed (each inline element onto its own
+        line), so this test makes the change easy to compare against master.
+        """
+        self.prettify("sample_mixed_content.xml")
+
+    def test_inline_elements_keep_text_flow(self):
+        """Empty inline elements in prose must not break the text flow.
+
+        On master the result is reflowed onto several lines.
+        """
+        observed = XMLPrettifier(
+            text=(
+                "<recipe>\n"
+                "  <p>This <cake_name/> uses <ingredient_count/> ingredients.</p>\n"
+                "</recipe>\n"
+            )
+        )()
+        self.assertIn(
+            "<p>This <cake_name /> uses <ingredient_count /> ingredients.</p>",
+            observed,
+        )
+
+    def test_inline_element_with_text_keeps_flow(self):
+        """Inline elements that contain text also stay within the prose flow."""
+        observed = XMLPrettifier(
+            text="<recipe>\n  <p>see the <a>method</a> below</p>\n</recipe>\n"
+        )()
+        self.assertIn("<p>see the <a>method</a> below</p>", observed)
+
+    def test_single_text_child_is_preserved(self):
+        """An element with a single text child keeps it inline (unchanged)."""
+        observed = XMLPrettifier(text="<root>\n  <p>just text</p>\n</root>\n")()
+        self.assertIn("<p>just text</p>", observed)
+
+    def test_block_content_is_reflowed_one_child_per_line(self):
+        """Element-only content laid out with whitespace stays one child per
+        line (preservation is limited to real prose, not structural markup)."""
+        observed = XMLPrettifier(text="<root>\n  <a/>\n  <b/>\n</root>\n")()
+        self.assertIn("\n  <a />\n", observed)
+        self.assertIn("\n  <b />\n", observed)
+
+    def test_blank_line_between_block_children_is_not_prose(self):
+        """A blank line between block children must not be mistaken for prose;
+        the children still reflow, indented. Regression guard for the internal
+        blank-line marker being counted as text.
+        """
+        observed = XMLPrettifier(text="<root>\n  <a/>\n\n  <b/>\n</root>\n")()
+        self.assertIn("\n  <a />\n", observed)
+        self.assertIn("  <b />", observed)


### PR DESCRIPTION
For XML, `XMLElement` sets `preserve_text_whitespace_elements = AnyIn()`, but the gate using it only fired for a single text child. So prose with inline elements (`<p>see <link/> here</p>`) was reflowed onto separate lines, changing
how it renders, not just the source.

Broaden `preserve_text_whitespace` to also cover real mixed/prose content (text that is not just whitespace or the blank-line marker) and render it keeping inline elements inline. Element-only content (and ZCML) still reflows as block.

Adds XML tests and a `sample_mixed_content.xml` fixture that reflow and fail on master, for easy comparison.