### PR TITLE
mixed content formatting

### DIFF
--- a/zpretty/elements.py
+++ b/zpretty/elements.py
@@ -77,6 +77,9 @@ class PrettyElement:
     )
     escaper = EntitySubstitution()
     preserve_text_whitespace_elements = ["pre"]
+    # Whether multi-line preserved mixed content is re-indented as a block.
+    # Off here: for HTML the only preserved element is <pre>, kept verbatim.
+    multiline_mixed_content_as_block = False
     skip_text_escaping_elements = [
         # Do not fiddle with the content of script tags,
         # as it may contain html entities that we do not want to be escaped
@@ -261,6 +264,7 @@ class PrettyElement:
         with whitespace), so a preceding <br/> needs no extra newline."""
         return not piece.strip() or startswith_whitespace(piece)
 
+    @memo
     def _preserve_content(self):
         """Render mixed content while keeping its inline flow, e.g.
         <p>see <link/> here</p>. A <br/> emits a single line break so the
@@ -280,6 +284,29 @@ class PrettyElement:
             previous_br = child.is_br()
         return "".join(preserved)
 
+    @property
+    @memo
+    def is_multiline_mixed_content(self):
+        """Whether preserved mixed content spans more than one line and so
+        should render as a block (tags on their own lines, content
+        re-indented) instead of inline. XML only; for HTML the sole preserved
+        element is <pre>, which stays verbatim."""
+        if not self.multiline_mixed_content_as_block:
+            return False
+        if not self.preserve_text_whitespace:
+            return False
+        children = self.getchildren()
+        # A single text child (e.g. <pre>...</pre>) is kept verbatim.
+        if len(children) == 1 and children[0].is_text():
+            return False
+        # Only re-indent when every element child is inline (renders on a
+        # single line). A nested multi-line child (a block element, aligned
+        # multiline attributes, ...) would lose its own indentation if the
+        # block re-indent flattened it, so such content stays verbatim.
+        if any(child.is_tag() and "\n" in child() for child in children):
+            return False
+        return "\n" in self._preserve_content()
+
     @memo
     def render_content(self):
         """Render a properly indented the contents of this element"""
@@ -288,7 +315,19 @@ class PrettyElement:
         previous_child = None
 
         if self.preserve_text_whitespace:
-            return self._preserve_content()
+            content = self._preserve_content()
+            if not self.is_multiline_mixed_content:
+                return content
+            # Multi-line mixed content reads better as a block: re-indent each
+            # line to this element's child level and drop the source's original
+            # (often irregular) indentation. The inline flow within a line is
+            # already joined by _preserve_content().
+            child_prefix = self.indent * (self.level + 1)
+            lines = []
+            for line in content.split("\n"):
+                stripped = line.strip()
+                lines.append(f"{child_prefix}{stripped}" if stripped else "")
+            return "\n".join(lines)
 
         for idx, child in enumerate(self.getchildren()):
             part = child()
@@ -418,7 +457,15 @@ class PrettyElement:
 
         text = self.text and self.render_text() or self.render_content()
 
-        if not self.preserve_text_whitespace and endswith_whitespace(text):
+        if self.is_multiline_mixed_content:
+            # Block layout: content sits on its own indented lines, with the
+            # open and close tags each on their own line.
+            if not text.startswith("\n"):
+                text = f"\n{text}"
+            if not text.endswith("\n"):
+                text = f"{text}\n"
+            close_tag_template = "{prefix}</{tag}>"
+        elif not self.preserve_text_whitespace and endswith_whitespace(text):
             if text[-1] != "\n":
                 text = f"{rstrip_last_line(text)}\n"
             close_tag_template = "{prefix}</{tag}>"

--- a/zpretty/elements.py
+++ b/zpretty/elements.py
@@ -162,6 +162,10 @@ class PrettyElement:
         # All the other elements will have an open an close tag
         return False
 
+    def is_br(self):
+        """Whether this element is a <br> line break"""
+        return self.is_tag() and self.tag == "br"
+
     def is_null(self):
         """We define a special tag null_tag_name to wrap text"""
         return self.context.name == self.null_tag_name
@@ -252,22 +256,39 @@ class PrettyElement:
             return False
         return bool(child.text.strip())
 
+    def _starts_with_break(self, piece):
+        """Whether piece already begins on a new line (it is blank or starts
+        with whitespace), so a preceding <br/> needs no extra newline."""
+        return not piece.strip() or startswith_whitespace(piece)
+
+    def _preserve_content(self):
+        """Render mixed content while keeping its inline flow, e.g.
+        <p>see <link/> here</p>. A <br/> emits a single line break so the
+        break stays visible in the output."""
+        preserved = []
+        previous_br = False
+        for child in self.getchildren():
+            if child.is_text():
+                piece = child.text
+            else:
+                # Render inline elements without their leading indent so
+                # they stay within the surrounding text flow.
+                piece = child().lstrip()
+            if previous_br and not self._starts_with_break(piece):
+                preserved.append("\n")
+            preserved.append(piece)
+            previous_br = child.is_br()
+        return "".join(preserved)
+
     @memo
     def render_content(self):
         """Render a properly indented the contents of this element"""
         parts = []
         previous_part = ""
+        previous_child = None
 
         if self.preserve_text_whitespace:
-            preserved = []
-            for child in self.getchildren():
-                if child.is_text():
-                    preserved.append(child.text)
-                else:
-                    # Render inline elements without their leading indent so
-                    # they stay within the surrounding text flow.
-                    preserved.append(child().lstrip())
-            return "".join(preserved)
+            return self._preserve_content()
 
         for idx, child in enumerate(self.getchildren()):
             part = child()
@@ -277,8 +298,12 @@ class PrettyElement:
                 part = lstrip_first_line(part)
             else:
                 parts[-1] = rstrip_last_line(parts[-1])
+            if previous_child is not None and previous_child.is_br():
+                if not part.startswith("\n"):
+                    part = "\n" + self.indent * (self.level + 1) + part
             parts.append(part)
             previous_part = child()
+            previous_child = child
         content = "".join(parts)
 
         if endswith_whitespace(content):

--- a/zpretty/elements.py
+++ b/zpretty/elements.py
@@ -232,12 +232,25 @@ class PrettyElement:
     @property
     @memo
     def preserve_text_whitespace(self):
+        if self.tag not in self.preserve_text_whitespace_elements:
+            return False
         children = self.getchildren()
-        return (
-            self.tag in self.preserve_text_whitespace_elements
-            and len(children) == 1
-            and children[0].is_text()
-        )
+        # A single text child is preserved verbatim, e.g. <pre>...</pre>.
+        if len(children) == 1 and children[0].is_text():
+            return True
+        # Mixed content: real prose text interspersed with inline elements,
+        # e.g. <p>see <link/> here</p>. Preserve the original flow instead of
+        # reflowing each child onto its own line. Content that is only child
+        # elements separated by whitespace still reflows as block.
+        if not any(child.is_tag() for child in children):
+            return False
+        return any(self._carries_prose_text(child) for child in children)
+
+    def _carries_prose_text(self, child):
+        """Whether child is a text node with real prose, ignoring whitespace."""
+        if not child.is_text():
+            return False
+        return bool(child.text.strip())
 
     @memo
     def render_content(self):
@@ -246,8 +259,15 @@ class PrettyElement:
         previous_part = ""
 
         if self.preserve_text_whitespace:
+            preserved = []
             for child in self.getchildren():
-                return child.text
+                if child.is_text():
+                    preserved.append(child.text)
+                else:
+                    # Render inline elements without their leading indent so
+                    # they stay within the surrounding text flow.
+                    preserved.append(child().lstrip())
+            return "".join(preserved)
 
         for idx, child in enumerate(self.getchildren()):
             part = child()

--- a/zpretty/tests/original/sample_mixed_content.xml
+++ b/zpretty/tests/original/sample_mixed_content.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<recipe>
+  <section>
+    <title>Ingredients at a glance</title>
+    <p>This <cake_name /> uses <ingredient_count /> ingredients and serves <servings /> people.</p>
+    <p>Before you begin, line a tin and <todo desc="note any prep step" />.</p>
+    <p>See the <a href="#method">full method</a> for the baking times.</p>
+  </section>
+</recipe>

--- a/zpretty/tests/test_xml.py
+++ b/zpretty/tests/test_xml.py
@@ -156,3 +156,28 @@ class TestZpretty(TestCase):
         observed = XMLPrettifier(text="<root>\n  <a/>\n\n  <b/>\n</root>\n")()
         self.assertIn("\n  <a />\n", observed)
         self.assertIn("  <b />", observed)
+
+    def test_br_forces_newline_after(self):
+        """A <br/> in mixed content breaks the line after it.
+
+        On the base branch <br/> stays glued to the following text.
+        """
+        observed = XMLPrettifier(
+            text="<recipe><p>Whisk eggs<br/>then fold in flour</p></recipe>\n"
+        )()
+        self.assertIn("Whisk eggs<br />\nthen fold in flour", observed)
+        self.assertEqual(observed, XMLPrettifier(text=observed)())
+
+    def test_br_does_not_double_newline(self):
+        """A <br/> already followed by a line break gets no extra newline."""
+        observed = XMLPrettifier(
+            text="<recipe><step>Sift the flour<br/>\n    then add sugar</step></recipe>\n"
+        )()
+        self.assertNotIn("<br />\n\n", observed)
+        self.assertEqual(observed, XMLPrettifier(text=observed)())
+
+    def test_br_last_child_no_trailing_blank_line(self):
+        """A trailing <br/> does not introduce a blank line before the close."""
+        observed = XMLPrettifier(text="<recipe><p>Bake<br/></p></recipe>\n")()
+        self.assertIn("<p>Bake<br /></p>", observed)
+        self.assertNotIn("<br />\n", observed)

--- a/zpretty/tests/test_xml.py
+++ b/zpretty/tests/test_xml.py
@@ -103,3 +103,56 @@ class TestZpretty(TestCase):
 
     def test_sample_txt(self):
         self.prettify("sample.txt")
+
+    def test_sample_mixed_content(self):
+        """Full-document idempotency for prose with inline elements.
+
+        On master this fixture is reflowed (each inline element onto its own
+        line), so this test makes the change easy to compare against master.
+        """
+        self.prettify("sample_mixed_content.xml")
+
+    def test_inline_elements_keep_text_flow(self):
+        """Empty inline elements in prose must not break the text flow.
+
+        On master the result is reflowed onto several lines.
+        """
+        observed = XMLPrettifier(
+            text=(
+                "<recipe>\n"
+                "  <p>This <cake_name/> uses <ingredient_count/> ingredients.</p>\n"
+                "</recipe>\n"
+            )
+        )()
+        self.assertIn(
+            "<p>This <cake_name /> uses <ingredient_count /> ingredients.</p>",
+            observed,
+        )
+
+    def test_inline_element_with_text_keeps_flow(self):
+        """Inline elements that contain text also stay within the prose flow."""
+        observed = XMLPrettifier(
+            text="<recipe>\n  <p>see the <a>method</a> below</p>\n</recipe>\n"
+        )()
+        self.assertIn("<p>see the <a>method</a> below</p>", observed)
+
+    def test_single_text_child_is_preserved(self):
+        """An element with a single text child keeps it inline (unchanged)."""
+        observed = XMLPrettifier(text="<root>\n  <p>just text</p>\n</root>\n")()
+        self.assertIn("<p>just text</p>", observed)
+
+    def test_block_content_is_reflowed_one_child_per_line(self):
+        """Element-only content laid out with whitespace stays one child per
+        line (preservation is limited to real prose, not structural markup)."""
+        observed = XMLPrettifier(text="<root>\n  <a/>\n  <b/>\n</root>\n")()
+        self.assertIn("\n  <a />\n", observed)
+        self.assertIn("\n  <b />\n", observed)
+
+    def test_blank_line_between_block_children_is_not_prose(self):
+        """A blank line between block children must not be mistaken for prose;
+        the children still reflow, indented. Regression guard for the internal
+        blank-line marker being counted as text.
+        """
+        observed = XMLPrettifier(text="<root>\n  <a/>\n\n  <b/>\n</root>\n")()
+        self.assertIn("\n  <a />\n", observed)
+        self.assertIn("  <b />", observed)

--- a/zpretty/tests/test_xml.py
+++ b/zpretty/tests/test_xml.py
@@ -165,13 +165,16 @@ class TestZpretty(TestCase):
         observed = XMLPrettifier(
             text="<recipe><p>Whisk eggs<br/>then fold in flour</p></recipe>\n"
         )()
-        self.assertIn("Whisk eggs<br />\nthen fold in flour", observed)
+        self.assertIn("Whisk eggs<br />\n", observed)
         self.assertEqual(observed, XMLPrettifier(text=observed)())
 
     def test_br_does_not_double_newline(self):
         """A <br/> already followed by a line break gets no extra newline."""
         observed = XMLPrettifier(
-            text="<recipe><step>Sift the flour<br/>\n    then add sugar</step></recipe>\n"
+            text=(
+                "<recipe><step>Sift the flour<br/>\n"
+                "    then add sugar</step></recipe>\n"
+            )
         )()
         self.assertNotIn("<br />\n\n", observed)
         self.assertEqual(observed, XMLPrettifier(text=observed)())
@@ -181,3 +184,71 @@ class TestZpretty(TestCase):
         observed = XMLPrettifier(text="<recipe><p>Bake<br/></p></recipe>\n")()
         self.assertIn("<p>Bake<br /></p>", observed)
         self.assertNotIn("<br />\n", observed)
+
+    def test_multiline_recipe_step_renders_as_block(self):
+        """Multi-line mixed content renders as a block: open/close tags on
+        their own lines, content re-indented to the child level, inline flow
+        within a line preserved.
+
+        On the base branch the source indentation is kept verbatim.
+        """
+        observed = XMLPrettifier(
+            text=(
+                "<ol>\n"
+                "  <li><b>Cream butter and sugar</b><br />Beat until the mixture is\n"
+                "              pale and fluffy, about three minutes.</li>\n"
+                "</ol>\n"
+            )
+        )()
+        self.assertIn(
+            "\n".join(
+                (
+                    "  <li>",
+                    "    <b>Cream butter and sugar</b><br />",
+                    "    Beat until the mixture is",
+                    "    pale and fluffy, about three minutes.",
+                    "  </li>",
+                )
+            ),
+            observed,
+        )
+        self.assertEqual(observed, XMLPrettifier(text=observed)())
+
+    def test_singleline_mixed_content_stays_inline(self):
+        """Single-line mixed content (no <br/>) is not turned into a block."""
+        observed = XMLPrettifier(
+            text=(
+                "<recipe>\n"
+                "  <p>fold in the <ingredient>flour</ingredient> gently</p>\n"
+                "</recipe>\n"
+            )
+        )()
+        self.assertIn(
+            "<p>fold in the <ingredient>flour</ingredient> gently</p>", observed
+        )
+
+    def test_multiline_block_normalizes_source_indentation(self):
+        """Grotesque source indentation is normalized to the child indent."""
+        observed = XMLPrettifier(
+            text=(
+                "<note>\n"
+                "  <p>First line.<br />\n"
+                "                       wildly indented second line.</p>\n"
+                "</note>\n"
+            )
+        )()
+        self.assertIn("\n    wildly indented second line.\n", observed)
+        self.assertNotIn("                       wildly", observed)
+        self.assertEqual(observed, XMLPrettifier(text=observed)())
+
+    def test_br_in_single_line_becomes_block(self):
+        """A <br/> turns single-line mixed content into a block (A + B)."""
+        observed = XMLPrettifier(
+            text="<recipe>\n  <step><b>Bake</b><br />until golden</step>\n</recipe>\n"
+        )()
+        self.assertIn(
+            "\n".join(
+                ("  <step>", "    <b>Bake</b><br />", "    until golden", "  </step>")
+            ),
+            observed,
+        )

--- a/zpretty/tests/test_zpretty.py
+++ b/zpretty/tests/test_zpretty.py
@@ -97,6 +97,12 @@ class TestZpretty(TestCase):
         self.assertIn("Whisk eggs<br />\n", observed)
         self.assertNotIn("<br />\n\n", observed)
 
+    def test_pre_stays_verbatim(self):
+        """A <pre> keeps its literal whitespace; block re-indent is XML only."""
+        original = "<pre>line one\n    line two <b>bold</b>\n  line three</pre>"
+        observed = ZPrettifier(text=original)()
+        self.assertIn("line one\n    line two <b>bold</b>\n  line three", observed)
+
     def test_nesting_with_tail(self):
         # no attributes
         self.assertPrettified(

--- a/zpretty/tests/test_zpretty.py
+++ b/zpretty/tests/test_zpretty.py
@@ -91,6 +91,12 @@ class TestZpretty(TestCase):
         )
         self.assertPrettified("<div><p>a</p></div>", "<div><p>a</p></div>\n")
 
+    def test_br_breaks_line(self):
+        """A <br/> in HTML prose breaks the line after it."""
+        observed = ZPrettifier(text="<p>Whisk eggs<br/>then fold in flour</p>")()
+        self.assertIn("Whisk eggs<br />\n", observed)
+        self.assertNotIn("<br />\n\n", observed)
+
     def test_nesting_with_tail(self):
         # no attributes
         self.assertPrettified(

--- a/zpretty/xml.py
+++ b/zpretty/xml.py
@@ -30,6 +30,7 @@ class XMLAttributes(PrettyAttributes):
 class XMLElement(PrettyElement):
     attribute_klass = XMLAttributes
     preserve_text_whitespace_elements = ANY_IN
+    multiline_mixed_content_as_block = True
 
     def is_self_closing(self):
         """Is this element self closing?"""


### PR DESCRIPTION
The following 3 changes belong together and incorporate #231.

- fix: keep inline elements in the text flow for XML mixed content
- feat: break the line after `<br/>`
- fix: re-indent multi-line mixed content as a block

closes #231