### PR TITLE
feat: collapse runs of 2+ blank lines to a single blank line

### DIFF
--- a/zpretty/elements.py
+++ b/zpretty/elements.py
@@ -299,7 +299,12 @@ class PrettyElement:
 
         If the text starts with spaces, strip them and add a newline.
         If the text end with spaces, strip them.
+
+        Consecutive blank lines are collapsed to a single blank line.
         """
+        from zpretty.prettifier import ZPrettifier
+
+        marker = ZPrettifier._newlines_marker
         text = self.text
         lines = text.split("\n")
         if not lines:
@@ -323,11 +328,19 @@ class PrettyElement:
         else:
             rendered_lines = [f"{lines[0]}\n"]
 
+        previous_blank = False
         for line in lines[1:-1]:
-            if not line.strip():
-                rendered_lines.append("\n")
+            if line == "" or line == marker:
+                # Collapse a run of blank/marker lines to one blank line.
+                if not previous_blank:
+                    rendered_lines.append("\n")
+                previous_blank = True
             else:
-                rendered_lines.append(f"{line.rstrip()}\n")
+                if not line.strip():
+                    rendered_lines.append("\n")
+                else:
+                    rendered_lines.append(f"{line.rstrip()}\n")
+                previous_blank = False
 
         if lines[-1].strip():
             if lines[-1].rstrip() == lines[-1]:

--- a/zpretty/tests/test_xml.py
+++ b/zpretty/tests/test_xml.py
@@ -48,3 +48,48 @@ class TestZpretty(TestCase):
 
     def test_sample_txt(self):
         self.prettify("sample.txt")
+
+    def test_two_blank_lines_between_blocks_collapse_to_one(self):
+        """Two blank lines between sibling recipe sections collapse to one."""
+        observed = XMLPrettifier(
+            text=(
+                "<recipe>\n"
+                "  <section>Sponge</section>\n"
+                "\n"
+                "\n"
+                "  <section>Buttercream</section>\n"
+                "</recipe>\n"
+            )
+        )()
+        self.assertIn(
+            "<section>Sponge</section>\n\n  <section>Buttercream</section>",
+            observed,
+        )
+        self.assertNotIn("</section>\n\n\n", observed)
+        self.assertEqual(observed, XMLPrettifier(text=observed)())
+
+    def test_single_blank_line_between_blocks_is_kept(self):
+        """A single blank line between sections is preserved."""
+        observed = XMLPrettifier(
+            text=(
+                "<recipe>\n"
+                "  <section>Sponge</section>\n"
+                "\n"
+                "  <section>Glaze</section>\n"
+                "</recipe>\n"
+            )
+        )()
+        self.assertIn(
+            "<section>Sponge</section>\n\n  <section>Glaze</section>", observed
+        )
+
+    def test_cdata_blank_lines_stay_verbatim(self):
+        """Blank lines inside CDATA (the secret recipe) are significant."""
+        observed = XMLPrettifier(
+            text=(
+                "<recipe><method>"
+                "<![CDATA[Cream butter\n\n\nfold in flour]]>"
+                "</method></recipe>\n"
+            )
+        )()
+        self.assertIn("<![CDATA[Cream butter\n\n\nfold in flour]]>", observed)

--- a/zpretty/tests/test_zcml.py
+++ b/zpretty/tests/test_zcml.py
@@ -232,3 +232,22 @@ class TestZpretty(TestCase):
 
     def test_zcml(self):
         self.prettify("sample.zcml")
+
+    def test_two_blank_lines_between_directives_collapse_to_one(self):
+        """Two blank lines between ZCML directives collapse to one."""
+        observed = ZCMLPrettifier(
+            text=(
+                "<configure>\n"
+                '  <include package=".oven" />\n'
+                "\n"
+                "\n"
+                '  <include package=".mixer" />\n'
+                "</configure>\n"
+            )
+        )()
+        self.assertIn(
+            '<include package=".oven" />\n\n  <include package=".mixer" />',
+            observed,
+        )
+        self.assertNotIn("/>\n\n\n", observed)
+        self.assertEqual(observed, ZCMLPrettifier(text=observed)())

--- a/zpretty/tests/test_zpretty.py
+++ b/zpretty/tests/test_zpretty.py
@@ -221,3 +221,23 @@ class TestZpretty(TestCase):
 
     def test_text_file(self):
         self.prettify("sample.txt")
+
+    def test_html_two_blank_lines_collapse_to_one(self):
+        """Two blank lines between HTML recipe paragraphs collapse to one."""
+        self.assertPrettified(
+            "<div><p>Preheat the oven</p>\n\n\n<p>Grease the tin</p></div>",
+            "<div><p>Preheat the oven</p>\n\n  <p>Grease the tin</p></div>\n",
+        )
+
+    def test_html_single_blank_line_is_kept(self):
+        """A single blank line between paragraphs is preserved."""
+        self.assertPrettified(
+            "<div><p>Preheat the oven</p>\n\n<p>Grease the tin</p></div>",
+            "<div><p>Preheat the oven</p>\n\n  <p>Grease the tin</p></div>\n",
+        )
+
+    def test_pre_keeps_internal_blank_lines(self):
+        """A <pre> recipe card keeps its internal blank lines verbatim."""
+        original = "<pre>Step 1: cream butter\n\n\nStep 2: add eggs</pre>"
+        observed = ZPrettifier(text=original)()
+        self.assertIn("Step 1: cream butter\n\n\nStep 2: add eggs", observed)


### PR DESCRIPTION
zpretty maximizes vertical space, so consecutive blank lines are redundant.

`render_text` now caps a run of blank lines (or blank-line markers) to one. Whitespace-significant content keeps its blank lines verbatim: `<pre>`, preserved XML prose and CDATA never reach `render_text`. Covers XML blank lines and the HTML/ZCML blank-line marker. Adds tests.