### PR TITLE
Fix possible issue with whitespaces lost around comments in XML documents

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,8 @@
 
 - Change the builder configuration to preserve whitespace in XML documents.
   @ale-rt
+- Fix possible issue with whitespaces lost around comments in XML documents.
+  @ale-rt
 
 
 ## 4.0.2 (2026-06-09)

--- a/zpretty/tests/test_xml.py
+++ b/zpretty/tests/test_xml.py
@@ -1,5 +1,6 @@
 from bs4 import BeautifulSoup
 from importlib.resources import files
+from textwrap import dedent
 from unittest import TestCase
 from zpretty.xml import XMLElement
 from zpretty.xml import XMLPrettifier
@@ -33,6 +34,60 @@ class TestZpretty(TestCase):
         """See #84"""
         element = self.get_element('<one \n foo="bar"\n\n\nbar="foo"\n/>')
         self.assertEqual(element(), '<one bar="foo"\n     foo="bar"\n/>')
+
+    def test_prolog_comment_newline(self):
+        """Check that a comment after the XML prolog is correctly formatted."""
+        expected = dedent("""\
+            <?xml version="1.0" encoding="utf-8"?>
+            <!-- comment -->
+            <parent>
+              <child>text</child>
+            </parent>
+        """)
+        template = dedent("""\
+            <?xml version="1.0" encoding="UTF-8"?>
+            {comment}
+            <parent>
+              <child>text</child>
+                </parent>
+        """)
+        for comment in (
+            "<!-- comment -->",
+            "<!-- comment -->\n",
+            "\n<!-- comment -->",
+        ):
+            original = template.format(comment=comment)
+            prettifier = XMLPrettifier(text=original)
+            observed = prettifier()
+            self.assertEqual(observed, expected, f"Failed for comment: {comment!r}")
+
+    def test_prolog_multiline_comment_newline(self):
+        expected = dedent("""\
+                <?xml version="1.0" encoding="utf-8"?>
+                <!--
+                  multiline
+                    comment
+                -->
+                <parent>
+                  <child>text</child>
+                </parent>
+            """)
+        template = dedent("""\
+            <?xml version="1.0" encoding="UTF-8"?>
+            {comment}
+            <parent>
+              <child>text</child>
+                </parent>
+        """)
+        for comment in (
+            "<!--\n  multiline\n    comment\n-->",
+            "\n<!--\n  multiline\n    comment\n-->",
+            "<!--\n  multiline\n    comment\n-->\n",
+        ):
+            original = template.format(comment=comment)
+            prettifier = XMLPrettifier(text=original)
+            observed = prettifier()
+            self.assertEqual(observed, expected, f"Failed for comment: {comment!r}")
 
     def test_xml(self):
         self.prettify("sample_xml.xml")

--- a/zpretty/xml.py
+++ b/zpretty/xml.py
@@ -1,4 +1,5 @@
 from bs4.builder import LXMLTreeBuilderForXML
+from bs4.element import Comment
 from bs4.element import NavigableString
 from logging import getLogger
 from zpretty.attributes import PrettyAttributes
@@ -64,6 +65,21 @@ class XMLPrettifier(ZPrettifier):
     pretty_element = XMLElement
     builder_class = LXMLTreeBuilderForXML
 
+    def restore_comment_newlines(self, soup):
+        """Reinsert top-level newlines between comments and following tags.
+
+        lxml's XML parser can drop pure-whitespace separators in this position,
+        which merges the comment and the following tag when rendering.
+        """
+        for child in list(soup.children):
+            if not isinstance(child, Comment):
+                continue
+
+            next_sibling = child.next_sibling
+            if next_sibling is None:
+                continue
+            child.insert_after(NavigableString("\n"))
+
     def get_soup(self, text):
         """Tries to get the soup from the given text
 
@@ -71,6 +87,7 @@ class XMLPrettifier(ZPrettifier):
         """
         original_soup = self.text2soup(text)
         if original_soup.is_xml:
+            self.restore_comment_newlines(original_soup)
             return original_soup
 
         markup = "<{null}>{text}</{null}>".format(


### PR DESCRIPTION
This should be a replacement for #229 

I think this is better as it is built on top of #237 that removes the need to use `_newlines_marker` from everywhere.

I also think it handles better the newlines after the comment.
